### PR TITLE
chore: refine Copilot PR workflow instructions

### DIFF
--- a/.github/prompts/create-pr.prompt.md
+++ b/.github/prompts/create-pr.prompt.md
@@ -1,0 +1,24 @@
+---
+name: "Create Pull Request"
+description: "Create a GitHub pull request with a structured title/body, assign the current user, and leave review and merge decisions manual."
+argument-hint: "Target branch, base branch, and PR summary"
+agent: "agent"
+---
+# Create Pull Request Prompt
+
+Create a pull request for the current branch using GitHub CLI when available.
+
+Workflow:
+
+1. Confirm the current branch, base branch, and working tree state.
+2. Create the PR with a concise, structured title and body.
+3. Add the current user as assignee with `gh pr edit <pr> --add-assignee "@me"`.
+4. Leave reviewers, labels, projects, and milestone available for manual follow-up unless explicitly requested.
+5. Do not enable auto-merge by default.
+
+Output requirements:
+
+- Report the PR URL.
+- State whether the assignee was added successfully.
+- State that review, labels, projects, milestone, and merge remain manual unless explicitly requested.
+- Mention any missing GitHub auth or permission scopes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,17 @@
 1. **Mapping Flow Rules**: [mapping-flow.instructions.md](.github/instructions/mapping-flow.instructions.md)
 1. **Parser Refactor Prompt**: [refactor-parser.prompt.md](.github/prompts/refactor-parser.prompt.md)
 1. **Validation Prompt**: [validate-workspace.prompt.md](.github/prompts/validate-workspace.prompt.md)
+1. **PR Creation Prompt**: [create-pr.prompt.md](.github/prompts/create-pr.prompt.md)
+
+## GitHub Workflow
+
+1. **Authentication**: Use `gh auth login` once per environment and verify with `gh auth status`
+1. **PR Creation**: Prefer `gh pr create` over browser-only flows when GitHub CLI is available
+1. **PR Quality**: Create PRs with a concise, appropriate title and a structured description that explains summary and key changes
+1. **Assignee**: After creating a PR, add the current user as assignee with `gh pr edit <pr> --add-assignee "@me"`
+1. **Manual Metadata**: Leave room for follow-up manual updates to labels, projects, and milestone after PR creation
+1. **Projects Scope**: If project updates are needed through `gh`, refresh auth with `gh auth refresh -s project`
+1. **Merge Flow**: Do not enable auto-merge by default. Prefer manual merge after review, then delete the remote branch when appropriate
 
 ## Runtime Constraints
 


### PR DESCRIPTION
## Summary

Refines workspace Copilot instructions for GitHub pull request handling.

## Changes

- add explicit guidance that PRs should use a concise, appropriate title and structured description
- add a dedicated PR creation prompt at .github/prompts/create-pr.prompt.md
- document gh-based PR creation, assignee handling, manual metadata updates, and manual merge flow
- keep reviewer handling and auto-merge out of the default workflow for stability

## Why

Makes the PR workflow more predictable and reduces accidental fast merges.
