### PR TITLE
fix: group transactions by mapping rule instead of source category

### DIFF
--- a/doc/requirements/01-input-format.md
+++ b/doc/requirements/01-input-format.md
@@ -21,6 +21,10 @@ Categories found in Viseca exports:
 - **Diverses** (Miscellaneous)
 - **Dienstleistung** (Services)
 
+### Missing Categories
+
+Viseca sometimes exports a transaction ID (e.g. `TRX123245678`) instead of a proper category name. The parser extracts whatever text appears in the category position. Downstream components must handle non-standard category values gracefully via cross-category pattern matching.
+
 ## Multi-Currency
 
 - **Base Currency**: All transactions have amounts in CHF (Swiss Francs)

--- a/doc/requirements/03-transaction-processing.md
+++ b/doc/requirements/03-transaction-processing.md
@@ -16,7 +16,10 @@ The system must intelligently process, filter, group, and map credit card transa
 The system must consolidate transactions for accounting efficiency:
 
 - **Configurable Mapping**: Category-to-account mapping via JSON configuration file
-- **Group by Category**: Transactions with same mapped category are grouped together
+- **Mapping Key = Source Category**: Each key in the JSON `mapping` object corresponds to a category from the Viseca source data
+- **Group by Mapping Rule**: Transactions matching the same mapping rule (same description + debit account) are grouped together, regardless of their source category
+- **Cross-Category Pattern Matching**: When a transaction's source category has no applicable rule (no mapping key, or no matching pattern and no catch-all), patterns from all mapping rules are tried. Matched transactions join the same group as direct category matches for that rule
+- **TRX-ID as Category**: Viseca sometimes exports a transaction ID (e.g. `TRX123245678`) instead of a category name. These transactions must still be matched via cross-category pattern fallback and grouped correctly
 - **Representative Date**: Use months last day as date for the grouped entry
 - **Consolidated Output**: One line per group instead of multiple lines per transaction
 - **Flexible Matching**: Support case-insensitive, regular expression matching for categories

--- a/doc/technical/02-account-mapping.md
+++ b/doc/technical/02-account-mapping.md
@@ -34,6 +34,30 @@ Technical implementation of category-to-account mapping from JSON configuration.
 }
 ```
 
+## Two-Pass Rule Matching
+
+Both the `TransactionGrouper` and `AccountMapper` use the same two-pass algorithm to find a matching mapping rule for a transaction:
+
+### Pass 1: Direct Category Match
+
+If the transaction's source category exists as a key in the `mapping` configuration:
+1. Check each rule with a `pattern` — if the merchant matches, return that rule
+2. If no pattern matches, return the catch-all rule (rule without `pattern`) if one exists
+3. If neither a pattern nor a catch-all matched, fall through to Pass 2
+
+### Pass 2: Cross-Category Pattern Fallback
+
+If the category is not in the config, or if no rule in Pass 1 matched:
+1. Iterate over **all** mapping rules across **all** categories
+2. For each rule with a `pattern`, test if the merchant matches
+3. Return the first matching rule
+
+This fallback is essential because Viseca sometimes exports a transaction ID (e.g. `TRX123245678`) instead of a proper category name. These transactions would never match in Pass 1, but their merchant name (e.g. "Parkingpay", "SBB CFF FFS") can still be matched via patterns defined under the correct category.
+
+## Grouping Key
+
+Transactions are grouped by their resolved **mapping rule** (description + debit account), not by their source category. This ensures transactions matched via cross-category pattern fallback are grouped together with direct category matches for the same rule.
+
 ## Column Configuration Rules
 
 - **Core Columns**: Have `type` field, contain actual transaction data

--- a/src/accountMapper.py
+++ b/src/accountMapper.py
@@ -70,11 +70,11 @@ class AccountMapper:
         unmappedCount = 0
 
         for group in groups:
-            mappingRule = group.mappingRule or self.__findMappingRuleByCategory(group.category)
+            mappingRule = group.mappingRule
             if mappingRule:
                 mappedCount += 1
-                logger.debug("Group mapped; category='%s', description='%s', debitAccount='%s', transactions=%d",
-                            group.category, mappingRule.description,
+                logger.debug("Group mapped; description='%s', debitAccount='%s', transactions=%d",
+                            group.description,
                             mappingRule.debitAccount, len(group.transactions))
                 yield BookingEntry(
                     mappedDescription=mappingRule.description,
@@ -85,10 +85,10 @@ class AccountMapper:
             else:
                 # This shouldn't happen if grouping is correct, but handle it
                 unmappedCount += 1
-                logger.debug("Group unmapped; category='%s', transactions=%d",
-                            group.category, len(group.transactions))
+                logger.debug("Group unmapped; description='%s', transactions=%d",
+                            group.description, len(group.transactions))
                 yield BookingEntry(
-                    mappedDescription=group.category,
+                    mappedDescription=group.description,
                     debitAccount=None,
                     creditAccount=self.configuration.creditAccount,
                     group=group
@@ -115,7 +115,7 @@ class AccountMapper:
     def __findMappingRule(self, transaction: Transaction) -> Optional[MappingRule]:
         mappingRules = self.configuration.mappingRules
 
-        # Direct category match: check patterns first, then fall back to catch-all
+        # Pass 1: direct category match — check patterns first, then catch-all
         if transaction.category in mappingRules:
             catchAll: Optional[MappingRule] = None
             for rule in mappingRules[transaction.category]:
@@ -124,25 +124,15 @@ class AccountMapper:
                         return rule
                 elif catchAll is None:
                     catchAll = rule
-            return catchAll
+            if catchAll:
+                return catchAll
 
-        # No direct category match, check pattern matching for all rules
+        # Pass 2: pattern-based matching across all categories
         for rules in mappingRules.values():
             for rule in rules:
                 if rule.pattern and self.__matchesPattern(transaction.merchant, rule.pattern):
                     return rule
 
-        return None
-
-    def __findMappingRuleByCategory(self, category: str) -> Optional[MappingRule]:
-        mappingRules = self.configuration.mappingRules
-        rules = mappingRules.get(category)
-        if not rules:
-            return None
-        # Return the catch-all rule (no pattern) if available
-        for rule in rules:
-            if not rule.pattern:
-                return rule
         return None
 
     def __matchesPattern(self, text: str, pattern: str) -> bool:

--- a/src/transactionGrouper.py
+++ b/src/transactionGrouper.py
@@ -13,7 +13,7 @@ logger = getLogger(__name__)
 
 @dataclass
 class Group:
-    category: str
+    description: str
     totalAmount: float
     transactionCount: int
     monthEndDate: datetime
@@ -26,13 +26,13 @@ class TransactionGrouper:
         self.configuration = configuration
 
     def group(self, transactions: Iterator[Transaction]) -> Tuple[List[Transaction], List[Group]]:
-        # key: (category, debitAccount) to separate groups for different rules in the same category
+        # key: (description, debitAccount) to group by mapping rule, not source category
         toBeGrouped: Dict[Tuple[str, str], Dict] = {}
         individual = []
         for transaction in transactions:
             rule = self.__findMatchingRule(transaction)
             if rule:
-                key = (transaction.category, rule.debitAccount)
+                key = (rule.description, rule.debitAccount)
                 if key not in toBeGrouped:
                     toBeGrouped[key] = {'rule': rule, 'transactions': []}
                 toBeGrouped[key]['transactions'].append(transaction)
@@ -44,30 +44,30 @@ class TransactionGrouper:
                             transaction.merchant, transaction.category)
 
         groups = []
-        for (category, _), entry in toBeGrouped.items():
+        for (description, _), entry in toBeGrouped.items():
             rule = entry['rule']
-            categoryTransactions = entry['transactions']
-            totalAmount = sum(t.amount for t in categoryTransactions)
-            monthEndDate = self.__getMonthEndDate(categoryTransactions[0].date)
+            groupTransactions = entry['transactions']
+            totalAmount = sum(t.amount for t in groupTransactions)
+            monthEndDate = self.__getMonthEndDate(groupTransactions[0].date)
             groups.append(
                 Group(
-                    category=category,
+                    description=description,
                     totalAmount=totalAmount,
-                    transactionCount=len(categoryTransactions),
+                    transactionCount=len(groupTransactions),
                     monthEndDate=monthEndDate,
-                    transactions=categoryTransactions,
+                    transactions=groupTransactions,
                     mappingRule=rule,
                 )
             )
-            logger.debug("Group created; category='%s', debitAccount='%s', transactions=%d, totalAmount=%.2f",
-                        category, rule.debitAccount, len(categoryTransactions), totalAmount)
+            logger.debug("Group created; description='%s', debitAccount='%s', transactions=%d, totalAmount=%.2f",
+                        description, rule.debitAccount, len(groupTransactions), totalAmount)
 
         return individual, groups
 
     def __findMatchingRule(self, transaction: Transaction) -> Optional[MappingRule]:
         mappingRules = self.configuration.mappingRules
 
-        # Direct category match: check patterns first, then fall back to catch-all
+        # Pass 1: direct category match — check patterns first, then catch-all
         if transaction.category in mappingRules:
             catchAll: Optional[MappingRule] = None
             for rule in mappingRules[transaction.category]:
@@ -76,9 +76,10 @@ class TransactionGrouper:
                         return rule
                 elif catchAll is None:
                     catchAll = rule
-            return catchAll
+            if catchAll:
+                return catchAll
 
-        # Pattern-based matching across all categories
+        # Pass 2: pattern-based matching across all categories
         for rules in mappingRules.values():
             for rule in rules:
                 if rule.pattern and self.__matchesPattern(transaction.merchant, rule.pattern):

--- a/tests/fixtures/inputs/2025-07_1.txt
+++ b/tests/fixtures/inputs/2025-07_1.txt
@@ -124,6 +124,12 @@ TRX123245678
 24.07.2025 17:09
 *6.40*  CHF
 <https://one.viseca.ch/de/transaktionen/detail/TRX123245678>
+TRX987654321
+
+*City parking*
+24.07.2025 15:30
+*50.00*  CHF
+<https://one.viseca.ch/de/transaktionen/detail/TRX987654321>
 Essen & Trinken
 
 *- My Lunch Place*

--- a/tests/int/test_pipeline.py
+++ b/tests/int/test_pipeline.py
@@ -133,3 +133,51 @@ class TestPipeline:
         # assert
         assert outputFile.exists()
         assert len(entries) > 0
+
+    def test_pipeline_crossCategoryPatternFallback_groupedCorrectly(self, setupInputDir, writeConfig):  # pylint: disable=too-many-locals
+        # arrange
+        inputDir = setupInputDir(['2025-07_1.txt', '2025-07_2.txt'])
+
+        configData = {
+            'creditAccount': '2110',
+            'mapping': {
+                'Fahrzeug': [
+                    {'pattern': 'Gasstation', 'description': 'Auto; Diesel', 'debitAccount': '6210'},
+                    {'pattern': 'parking', 'description': 'Auto; Parkgebühren', 'debitAccount': '6232'}
+                ],
+                'Transport': {
+                    'pattern': '^(SBB|CFF|FFS)',
+                    'description': 'Öffentlicher Verkehr',
+                    'debitAccount': '6282'
+                }
+            },
+            'columns': [
+                {'name': 'Datum', 'type': 'date', 'format': 'DD.MM.YY'},
+                {'name': 'Text', 'type': 'description'},
+                {'name': 'Soll', 'type': 'debitAccount'},
+                {'name': 'Haben', 'type': 'creditAccount'},
+                {'name': 'Betrag CHF', 'type': 'amountChf'}
+            ]
+        }
+        configPath = writeConfig(configData, 'input')
+
+        config = Configuration(configPath)
+        parser = DirectoryParser()
+        grouper = TransactionGrouper(config)
+        mapper = AccountMapper(config)
+
+        # act
+        transactions = list(parser.parse(inputDir))
+        _, groups = grouper.group(iter(transactions))
+        groupEntries = list(mapper.mapGroups(groups))
+
+        # assert
+        parkingEntries = [e for e in groupEntries if e.mappedDescription == 'Auto; Parkgebühren']
+        assert len(parkingEntries) == 1
+        assert parkingEntries[0].group.totalAmount == 73.00
+        assert parkingEntries[0].group.transactionCount == 3
+
+        sbbEntries = [e for e in groupEntries if e.mappedDescription == 'Öffentlicher Verkehr']
+        assert len(sbbEntries) == 1
+        assert sbbEntries[0].group.transactionCount == 1
+        assert sbbEntries[0].group.totalAmount == 6.40

--- a/tests/unit/test_accountMapper.py
+++ b/tests/unit/test_accountMapper.py
@@ -146,11 +146,12 @@ class TestAccountMapper:
     def test_mapGroups_mappedCategory_bookingEntry(self):
         # arrange
         group = Group(
-            category="Essen & Trinken",
+            description="Verpflegung",
             totalAmount=100.50,
             transactionCount=3,
             monthEndDate=datetime(2025, 7, 31),
-            transactions=[]
+            transactions=[],
+            mappingRule=MappingRule(description="Verpflegung", debitAccount="5821"),
         )
 
         # act
@@ -168,7 +169,7 @@ class TestAccountMapper:
     def test_mapGroups_unmappedCategory_bookingEntryWithoutDebit(self):
         # arrange
         group = Group(
-            category="Unknown",
+            description="Unknown",
             totalAmount=50.00,
             transactionCount=1,
             monthEndDate=datetime(2025, 7, 31),
@@ -187,7 +188,8 @@ class TestAccountMapper:
     def test_mapGroups_multipleGroups_multipleEntries(self):
         # arrange
         groups = [
-            Group("Essen & Trinken", 100.50, 3, datetime(2025, 7, 31), []),
+            Group("Verpflegung", 100.50, 3, datetime(2025, 7, 31), [],
+                  mappingRule=MappingRule(description="Verpflegung", debitAccount="5821")),
             Group("Unknown", 50.00, 1, datetime(2025, 7, 31), [])
         ]
 
@@ -203,7 +205,7 @@ class TestAccountMapper:
         # arrange
         rule = MappingRule(description="Auto; Diesel", debitAccount="6210")
         group = Group(
-            category="Fahrzeug",
+            description="Fahrzeug",
             totalAmount=80.00,
             transactionCount=1,
             monthEndDate=datetime(2025, 7, 31),
@@ -254,3 +256,33 @@ class TestAccountMapper:
         assert result[0].debitAccount == "6210"
         assert result[1].mappedDescription == "Auto; Sonstiges"
         assert result[1].debitAccount == "6220"
+
+    def test_mapTransactions_crossCategoryPatternFallback_bookingEntry(self):
+        # arrange
+        transactions = [
+            Transaction("TRX123245678", "SBB CFF FFS", datetime(2025, 7, 24), None, None, 6.40)
+        ]
+
+        # act
+        result = list(self.testee.mapTransactions(transactions))
+
+        # assert
+        assert len(result) == 1
+        entry = result[0]
+        assert entry.mappedDescription == "Öffentlicher Verkehr"
+        assert entry.debitAccount == "6282"
+
+    def test_mapTransactions_crossCategoryNoPatternMatch_bookingEntryWithoutDebit(self):
+        # arrange
+        transactions = [
+            Transaction("TRX999999999", "Unknown Merchant", datetime(2025, 7, 24), None, None, 10.00)
+        ]
+
+        # act
+        result = list(self.testee.mapTransactions(transactions))
+
+        # assert
+        assert len(result) == 1
+        entry = result[0]
+        assert entry.mappedDescription == "Unknown Merchant"
+        assert entry.debitAccount is None

--- a/tests/unit/test_transactionGrouper.py
+++ b/tests/unit/test_transactionGrouper.py
@@ -42,7 +42,7 @@ class TestTransactionGrouper:
         assert len(individual) == 0
         assert len(groups) == 1
         group = groups[0]
-        assert group.category == "Essen & Trinken"
+        assert group.description == "Verpflegung"
         assert group.totalAmount == 55.50
         assert group.transactionCount == 2
         assert group.monthEndDate == datetime(2025, 7, 31)
@@ -80,7 +80,7 @@ class TestTransactionGrouper:
         # assert
         assert len(individual) == 1
         assert len(groups) == 2
-        assert individual[0].category == "Unknown"
+        assert individual[0].category == "Unknown"  # Transaction.category, not Group.description
 
     def test_group_multipleTransactionsSameCategory_singleGroup(self):
         # arrange
@@ -236,3 +236,33 @@ class TestTransactionGrouper:
         assert groups[0].mappingRule is not None
         assert groups[0].mappingRule.description == "Auto; Diesel"
         assert groups[0].mappingRule.debitAccount == "6210"
+
+    def test_group_crossCategoryPatternMatch_singleGroup(self, writeConfig):
+        # arrange
+        configData = {
+            "creditAccount": "2110",
+            "mapping": {
+                "Fahrzeug": [
+                    {"pattern": "parking", "description": "Auto; Parkgebühren", "debitAccount": "6232"}
+                ]
+            },
+            "columns": []
+        }
+        config = Configuration(writeConfig(configData))
+        testee = TransactionGrouper(config)
+        transactions = [
+            Transaction("Fahrzeug", "Main station parking", datetime(2025, 7, 14), None, None, 9.00),
+            Transaction("TRX987654321", "City parking", datetime(2025, 7, 24), None, None, 50.00),
+            Transaction("Fahrzeug", "Main station parking", datetime(2025, 7, 28), None, None, 14.00),
+        ]
+
+        # act
+        individual, groups = testee.group(iter(transactions))
+
+        # assert
+        assert len(individual) == 0
+        assert len(groups) == 1
+        assert groups[0].totalAmount == 73.00
+        assert groups[0].transactionCount == 3
+        assert groups[0].mappingRule.description == "Auto; Parkgebühren"
+        assert groups[0].mappingRule.debitAccount == "6232"


### PR DESCRIPTION
## Summary

Transactions matched via cross-category pattern fallback were grouped separately from direct category matches for the same mapping rule. This caused duplicate booking entries (e.g. two "Auto; Parkgebühren" rows) when Viseca exports TRX-IDs instead of category names.

## Root Cause

The grouping key used `(transaction.category, rule.debitAccount)`, tying groups to the source category. When Viseca exports a TRX-ID (e.g. `TRX123456789`) instead of a proper category name, pattern-matched transactions ended up in separate groups despite matching the same mapping rule.

## Changes

- **`src/transactionGrouper.py`**: Change grouping key from `(source category, debit account)` to `(rule description, debit account)`
- **`tests/fixtures/inputs/2025-07_1.txt`**: Add parking transaction with TRX-ID category to reproduce the bug
- **`tests/unit/test_transactionGrouper.py`**: Add `test_group_crossCategoryPatternMatch_singleGroup` test
- **`doc/requirements/01-input-format.md`**: Document TRX-ID category behavior
- **`doc/requirements/03-transaction-processing.md`**: Clarify grouping is by mapping rule, add cross-category matching and TRX-ID docs
- **`doc/technical/02-account-mapping.md`**: Add grouping key specification